### PR TITLE
feat: hamlet engine management support

### DIFF
--- a/vars/setHamletEngine.groovy
+++ b/vars/setHamletEngine.groovy
@@ -1,0 +1,24 @@
+// Set the hamlet engine to use for
+def call(
+    String engine,
+    Boolean update = false
+) {
+    script {
+        env['required_hamlet_engine'] = engine
+        env['update_hamlet_engine'] = update
+    }
+
+    // The agent may already have the required version installed
+    sh '''#!/bin/bash
+        current_hamlet_engine="$(hamlet engine get-engine)"
+        if [[ ! ("${current_hamlet_engine}" == ${required_hamlet_engine}) ]]; then
+            hamlet engine install-engine "${required_hamlet_engine}"
+        fi
+
+        if [[ "${update_hamlet_engine}" == "true" ]]; then
+            hamlet engine install-engine --update "${required_hamlet_engine}"
+        fi
+
+        hamlet engine set-engine "${required_hamlet_engine}"
+    '''
+}

--- a/vars/setHamletEngine.txt
+++ b/vars/setHamletEngine.txt
@@ -1,0 +1,28 @@
+<p>
+Set the engine to use for all hamlet commands
+</p>
+<em>Parameters</em>
+<p>
+<dl>
+<dt>engine</dt>
+<dd>
+The desired hamlet engine to use
+To find available engines install hamlet and run
+<code>
+hamlet engine list-engines
+<code>
+</dd>
+</dl>
+</p>
+<em>Notes</em>
+<p>
+<ul>
+<li>
+Named engines include
+<ul>
+<li>unicycle - the latest version of hamlet available</li>
+<li>tram - the latest tested nightly build of hamlet</li>
+<li>train - the latest stable release of hamlet</li>
+</li>
+</ul>
+</p>


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)


## Description

Adds a step to specify and install a specific version of hamlet that will be used throughout the pipeline

## Motivation and Context

Allows for setting specific versions of the hamlet engine to use to ensure stability in the engine or access to latest updates as required

## How Has This Been Tested?

Will be tested as part of a new deployment

## Related Changes

### Prerequisite PRs:

 - Requires https://github.com/hamlet-io/executor-python/pull/214 which adds some of the extra commands required 
 
### Dependent PRs:

- None

### Consumer Actions:

- None

