### PR TITLE
feat: image paths for upload

### DIFF
--- a/vars/uploadArtifactsToRegistry.groovy
+++ b/vars/uploadArtifactsToRegistry.groovy
@@ -3,7 +3,8 @@ def call(
     String deployment_unit,
     String scope,
     String image_formats,
-    String git_commit
+    String git_commit,
+    String image_paths = "",
 ) {
     // Inject parameters into the environment for the script steps
     // Variable names are treated as case insensitive so rename to avoid overwriting existing
@@ -13,6 +14,7 @@ def call(
         env['upload_scope'] = scope
         env['upload_image_formats'] = image_formats
         env['upload_git_commit'] = git_commit
+        env['upload_image_paths'] = image_paths
     }
 
     sh '''#!/bin/bash
@@ -25,8 +27,14 @@ def call(
     }
 
     sh '''#!/bin/bash
-        for upload_image_format in ${upload_image_formats}; do
-            ${AUTOMATION_DIR}/manageImages.sh -u "${upload_deployment_unit}" -c "${upload_scope}" -f "${upload_image_formats,,}" -g "${upload_git_commit}" || exit $?
+        for i in "${!upload_image_formats[@]}"; do
+            image_args=()
+
+            if [[ -n "${upload_image_paths[i]}" ]]; then
+                image_args+=("-i" "${upload_image_paths[i]}")
+            fi
+
+            ${AUTOMATION_DIR}/manageImages.sh -u "${upload_deployment_unit}" -c "${upload_scope}" -f "${upload_image_formats[i],,}" -g "${upload_git_commit}" "${image_args[@]} || exit $?
         done
     '''
 }

--- a/vars/uploadArtifactsToRegistry.txt
+++ b/vars/uploadArtifactsToRegistry.txt
@@ -20,13 +20,17 @@ The registries to which the image should be uploaded.
 <dd>
 The commit hash from which the artifact was built.
 </dd>
+<dt>image_paths</dt>
+<dd>
+The paths to the images for each format that you want to create
+</dd>
 </dl>
 </p>
 <em>Notes</em>
 <p>
 <ul>
 <li>
-this step assumes the artifact is in zip format and named according to the image formats provided e.g. <code>lambda.zip</code>
+<code>The path can either be to a directory or to a zip file. If a directory is provided it will be zipped to create the image</code>
 </li>
 </ul>
 </p>


### PR DESCRIPTION
## Intent of Change

- New feature (non-breaking change which adds functionality)


## Description

Adds support for providing an explicit image path that will be used as the source image when running manage images. 
This includes providing a directory that will be zipped for you

## Motivation and Context

Make it easier to provide the images that you need to push

## How Has This Been Tested?

Will be tested on build pipeline

## Related Changes

### Prerequisite PRs:

- None

### Dependent PRs:

- None

### Consumer Actions:

- None

