### PR TITLE
fix: null registry scope for artifact upload

### DIFF
--- a/vars/uploadArtifactsToRegistry.groovy
+++ b/vars/uploadArtifactsToRegistry.groovy
@@ -27,6 +27,12 @@ def call(
     }
 
     sh '''#!/bin/bash
+        # Compensate for Jenkinsfile behaviour where setting an environment variable to an
+        # empty string results in a value of null being returned
+        if [[ "${upload_scope}" == "null" ]]; then
+          upload_scope=""
+        fi
+
         for i in "${!upload_image_formats[@]}"; do
             image_args=()
 


### PR DESCRIPTION

## Intent of Change
- Bug fix (non-breaking change which fixes an issue)

## Description
Check for a registry scope of null and treat as an empty scope.

## Motivation and Context
Get around some buggy groovy/Jenkinsfile behaviour.

## How Has This Been Tested?
Tested in Jenkins once merged

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

