### PR TITLE
feat: broader range of office URL formats

### DIFF
--- a/vars/notifyChannels.groovy
+++ b/vars/notifyChannels.groovy
@@ -18,7 +18,7 @@ def call(
                 )
             }
 
-            if (channel.startsWith("https://outlook.office.com/webhook/")) {
+            if (channel.indexOf("office.com") != -1) {
                 // Standard Office 365 format includes JOB NAME and BUILD_URL
                 office365ConnectorSend (
                     message: "**${title}** | ${BUILD_DISPLAY_NAME}  \n${message}",
@@ -29,4 +29,3 @@ def call(
         }
     }
 }
-

--- a/vars/notifyChannels.txt
+++ b/vars/notifyChannels.txt
@@ -17,7 +17,7 @@ The detail of the notification
 A comma separated list of channels. Currently accepted formats are
 <ul>
 <li>slack channels (recognised as starting with a "<code>#</code>")</li>
-<li>Office Teams (recognised as starting with "<code>https://outlook.office.com/webhook/</code>")</li>
+<li>Office Teams (recognised as containing "<code>office.com</code>")</li>
 </ul>
 </dd>
 <dt>colour</dt>


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
Apply a more generous rule to determine that a channel is an Microsoft Office Teams Post.

## Motivation and Context
Link formats appear to have changed.

## How Has This Been Tested?
Will be tested as part of customer deployment.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

