### PR TITLE
feat: nodejs/python scoping control

### DIFF
--- a/vars/installNode.groovy
+++ b/vars/installNode.groovy
@@ -1,9 +1,11 @@
 // Set the node environment to the version specified
 def call(
-    String version
+    String version,
+    String scope = "global"
 ) {
     script {
         env['required_nodejs_version'] = version
+        env['required_scope'] = scope
     }
 
     // The agent may already have the required version installed
@@ -12,7 +14,11 @@ def call(
         if [[ ! ("${current_nodejs_version}" =~ ${required_nodejs_version}) ]]; then
             nodenv install "${required_nodejs_version}" ||
                 { nodenv install --list; exit 1; }
-            nodenv global  "${required_nodejs_version}" || exit $?
+            case ${required_scope} in
+              global|local)
+                nodenv ${required_scope} "${required_nodejs_version}" || exit $?
+                ;;
+            esac
         fi
         nodenv version || exit $?
     '''

--- a/vars/installNode.txt
+++ b/vars/installNode.txt
@@ -9,6 +9,13 @@ Install a version of nodejs.
 The desired version. Version must be supported by <code>nodeenv</code>
 </dd>
 </dl>
+<dl>
+<dt>scope</dt>
+<dd>
+The desired scoping for the installation. Possible values are "global" and "local".
+Any other value will be ignored, meaning the version will be installed but not activated.
+</dd>
+</dl>
 </p>
 <em>Notes</em>
 <p>

--- a/vars/installPython.groovy
+++ b/vars/installPython.groovy
@@ -1,9 +1,11 @@
 // Set the python environment to the version specified
 def call(
-    String version
+    String version,
+    String scope = "global"
 ) {
     script {
         env['required_python_version'] = version
+        env['required_scope'] = scope
     }
 
     // The agent may already have the required version installed
@@ -12,8 +14,11 @@ def call(
         if [[ ! ("${current_python_version}" =~ ${required_python_version}) ]]; then
             pyenv install "${required_python_version}" ||
                 { pyenv install --list; exit 1; }
-            pyenv global  "${required_python_version}" || exit $?
-            pip install --upgrade awscli pip virtualenv || exit $?
+            case ${required_scope} in
+              global|local)
+                pyenv ${required_scope} "${required_python_version}" || exit $?
+                ;;
+            esac
         fi
         pyenv version || exit $?
         pip install --upgrade awscli pip virtualenv || exit $?

--- a/vars/installPython.txt
+++ b/vars/installPython.txt
@@ -9,6 +9,13 @@ Install a version of python.
 The desired version. Version must be supported by <code>pyenv</code>
 </dd>
 </dl>
+<dl>
+<dt>scope</dt>
+<dd>
+The desired scoping for the installation. Possible values are "global" and "local".
+Any other value will be ignored, meaning the version will be installed but not activated.
+</dd>
+</dl>
 </p>
 <em>Notes</em>
 <p>


### PR DESCRIPTION
## Intent of Change
- New feature (non-breaking change which adds functionality)

## Description
When installing new versions of nodejs or python, permit the scope of the command to be controlled.

## Motivation and Context
Permit more control over the scope in which a new version should apply. optionally permit a version to be installed but not made active at all.

## How Has This Been Tested?
Targetted client installation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

