### PR TITLE
fix: hamlet cli version

### DIFF
--- a/vars/setHamletEngine.groovy
+++ b/vars/setHamletEngine.groovy
@@ -1,15 +1,20 @@
 // Set the hamlet engine to use for
 def call(
     String engine,
-    Boolean update = false
+    Boolean update = false,
+    String cliVersion = ''
 ) {
     script {
         env['required_hamlet_engine'] = engine
         env['update_hamlet_engine'] = update
+        env['hamlet_cli_version'] = cliVersion
     }
 
     // The agent may already have the required version installed
     sh '''#!/bin/bash
+
+        pip install --upgrade "hamlet${hamlet_cli_version}"
+
         current_hamlet_engine="$(hamlet engine get-engine)"
         if [[ ! ("${current_hamlet_engine}" == ${required_hamlet_engine}) ]]; then
             hamlet engine install-engine "${required_hamlet_engine}"
@@ -20,5 +25,8 @@ def call(
         fi
 
         hamlet engine set-engine "${required_hamlet_engine}"
+
+        echo "hamlet version = \"$(hamlet --version)\""
+        echo "hamlet engine = \"$(hamlet engine get-engine)\""
     '''
 }

--- a/vars/setHamletEngine.txt
+++ b/vars/setHamletEngine.txt
@@ -12,6 +12,17 @@ To find available engines install hamlet and run
 hamlet engine list-engines
 <code>
 </dd>
+<dt>update</dt>
+<dd>
+If the string true is provided, the engine is
+updated even if already installed.
+</dd>
+<dt>cliVersion</dt>
+<dd>
+The latest official version of hamlet cli is installed
+by default. If provided, this parameter is used to
+specify the version required per pip syntax.
+</dd>
 </dl>
 </p>
 <em>Notes</em>


### PR DESCRIPTION
## Intent of Change
<!-- Delete all that do not apply                      -->
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Rather than relying on the hamlet cli being present, or at a recent version, explicitly install the cli and request an upgrade.

Add an optional parameter to provide the ability to constrain the version per standard pip syntax.

## Motivation and Context
Make the library routine more robust but permit version locking if desired.

## How Has This Been Tested?
Will be tested in customer site once tagged and release.

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

