### PR TITLE
fix: align to current hamlet cli behaviour

### DIFF
--- a/vars/setHamletEngine.groovy
+++ b/vars/setHamletEngine.groovy
@@ -13,20 +13,13 @@ def call(
     // The agent may already have the required version installed
     sh '''#!/bin/bash
 
-        pip install --upgrade "hamlet${hamlet_cli_version}"
-
-        current_hamlet_engine="$(hamlet engine get-engine)"
-        if [[ ! ("${current_hamlet_engine}" == ${required_hamlet_engine}) ]]; then
-            hamlet engine install-engine "${required_hamlet_engine}"
-        fi
-
-        if [[ "${update_hamlet_engine}" == "true" ]]; then
-            hamlet engine install-engine --update "${required_hamlet_engine}"
-        fi
-
-        hamlet engine set-engine "${required_hamlet_engine}"
-
+        echo "Updating the hamlet cli ..."
+        pip install --silent --upgrade "hamlet${hamlet_cli_version}"
         echo "hamlet version = \"$(hamlet --version)\""
+
+        echo "Updating the hamlet engine to ${required_hamlet_engine} ..."
+        hamlet engine install-engine --update "${required_hamlet_engine}"
+        hamlet engine set-engine "${required_hamlet_engine}"
         echo "hamlet engine = \"$(hamlet engine get-engine)\""
     '''
 }


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Simplify the implementation to always force an install of the required hamlet engine version.

## Motivation and Context
Avoid odd effects as a result of using HAMLET_ENGINE to specify the required engine version
in Jenkinsfile.

## How Has This Been Tested?
Tested with customer installation

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

