### PR TITLE
feat: CMDB construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ The following steps are provided to streamline the development of build pipeline
 - installMaven
 - installNode
 - loadCMDB
+- loadPropertiesFiles
 - loadProperties
 - notifyBuildFailure
 - notifyBuildSuccess

--- a/vars/loadCMDB.groovy
+++ b/vars/loadCMDB.groovy
@@ -1,28 +1,53 @@
-// Load a product CMDB to get access to the stream pipelines
+// Load a product repo to get access to the stream pipelines
+// Optionally load the accounts repo to permit hamlet based
+// deployments.
 def call(
-    String product_cmdb_url = '',
-    String branch = 'master',
-    String credentialsId = 'github'
+    String product_cmdb_url,
+    String product_cmdb_branch = 'master',
+    String credentialsId = 'github',
+    String accounts_cmdb_url = '',
+    String accounts_cmdb_branch = 'master',
+    String product_path = 'product',
+    String accounts_path = 'accounts',
+    String cmdb_path = ".hamlet/cmdb",
+    String cmdb_root_env_name = 'ROOT_DIR'
 ) {
-    // Product Setup
-    dir('.hamlet/product') {
-        script {
-            if (product_cmdb_url == '') {
-                // CMDB is configured as part of the pipeline
-                // Skip the default commit so we can force the value
-                // of GIT_COMMIT in the environment when updating build
-                // references.
-                checkout scm
-            } else {
-                // Need to load CMDB - don't include it in changelog calculations
+    dir( "${cmdb_path}" ) {
+
+        // Always load product repo as a minimum
+        // It can contain accounts info as well
+        dir( "${product_path}" ) {
+            script {
+                // Don't include it in changelog calculations
                 git(
                     url: product_cmdb_url,
-                    branch: branch,
+                    branch: product_cmdb_branch,
                     credentialsId: credentialsId,
                     changelog: false,
                     poll: false
                 )
             }
+        }
+
+        // Accounts Setup
+        dir( "${accounts_path}" ) {
+            script {
+                if ( accounts_cmdb_url ) {
+                    // Need to load accounts repo - don't include it in changelog calculations
+                    git(
+                        url: accounts_cmdb_url,
+                        branch: accounts_cmdb_branch,
+                        credentialsId: credentialsId,
+                        changelog: false,
+                        poll: false
+                    )
+                }
+            }
+        }
+
+        // Remember where the CMDB has been constructed
+        script {
+            env["${cmdb_root_env_name}"] = sh(script: 'pwd', returnStdout: true).trim()
         }
     }
 }

--- a/vars/loadCMDB.txt
+++ b/vars/loadCMDB.txt
@@ -6,16 +6,46 @@ Clone the product CMDB into a reserved location in the workspace.
 <dl>
 <dt>product_cmdb_url</dt>
 <dd>
-The full URL to the git repository for the product. If blank, the repo is assumed to be configured on the job itself so
-a checkout is performed. If not blank, the repository is checked out.
+The full URL to the git repository for the product.
 </dd>
-<dt>branch</dt>
+<dt>product_cmdb_branch</dt>
 <dd>
-The branch to be loaded. By default <code>master</code> is used.
+The product branch to be loaded. By default <code>master</code> is used.
 </dd>
 <dt>credentialsId</dt>
 <dd>
 The id of the jenkins credential to use to access the git provider. By default <code>github</code> is used.
+</dd>
+<dt>accounts_cmdb_url</dt>
+<dd>
+The full URL to the git repository for the accounts. If blank, no processing of the accounts repo is performed.
+The common situation for this is a single repo containing both product and account information.
+If not blank, the repository is checked out.
+</dd>
+<dt>acount_cmdb_branch</dt>
+<dd>
+The accounts branch to be loaded. By default <code>master</code> is used.
+</dd>
+<dt>product_path</dt>
+<dd>
+The path under <code>cmdb_path</code> where the product branch is checked out. By default <code>product</code> is used.
+If checking out in conjunction with an accounts repo and assuming the config for only one product is in the repo,
+this must be the id of the product.
+</dd>
+<dt>accounts_path</dt>
+<dd>
+The path under <code>cmdb_path</code> where the accounts branch is checked out. By default <code>accounts</code> is used.
+If checking out in conjunction with a product repo and assuming the config for only one account is in the repo,
+this must be the id of the account.
+</dd>
+<dt>cmdb_path</dt>
+<dd>
+The relative path to the root of the CMDB. By default <code>.hamlet/cmdb</code> is used.
+</dd>
+<dt>cmdb_path</dt>
+<dd>
+The name of the environment variable to hold the path to the root of the CMDB.
+By default <code>ROOT_DIR</code> is used to match the expectations of the hamlet CLI.
 </dd>
 </dl>
 </p>

--- a/vars/loadProperties.groovy
+++ b/vars/loadProperties.groovy
@@ -1,19 +1,21 @@
-// Load properties defined in the CMDB into the environment
+// Load properties from a file
 def call(
     String properties_file,
-    String noWorkspace = 'false'
+    String noWorkspace = 'false',
+    String properties_path = 'pipelines/properties/',
+    String properties_extension = '.properties'
 ) {
     script {
         if (noWorkspace.toBoolean()) {
             // Assume CMDB configured on the job
-            def fileContent = readTrusted path: "pipelines/properties/${properties_file}.properties"
+            def fileContent = readTrusted path: "${properties_path}${properties_file}${properties_extension}"
             def contextProperties = readProperties interpolate: true, text: fileContent
             contextProperties.each{ k, v -> env["${k}"] ="${v}" }
         } else {
             // CMDB is local in the workspace
-            dir('.hamlet/product') {
+            dir(".hamlet/properties") {
                 // Load in the properties file from the cmdb
-                def contextProperties = readProperties interpolate: true, file: "pipelines/properties/${properties_file}.properties";
+                def contextProperties = readProperties interpolate: true, file: "${properties_path}${properties_file}${properties_extension}";
                 contextProperties.each{ k, v -> env["${k}"] ="${v}" }
             }
         }

--- a/vars/loadProperties.txt
+++ b/vars/loadProperties.txt
@@ -1,17 +1,26 @@
 <p>
-Load a set of properties froma file in the CMDB
+Load a set of properties from a file. The filename is constructed from the path, file and path properties.
 </p>
 <em>Parameters</em>
 <p>
 <dl>
 <dt>properties_file</dt>
 <dd>
-The filename without extension. It is assumed to be in the <code>pipelines/properties</code> directory of the CMDB and have a <code>.properties</code> extension.
+The filename without extension.
 </dd>
 <dt>noWorkspace</dt>
 <dd>
-If true, the job is assumed to not have a workspace, in which case the CMDB repository is assumed to be configured on the job and the file is accessed using the readTrusted step.
-If false, the CMDB is assumed to be installed locally in a reserved location.
+If true, the job is assumed to not have a workspace, in which case a repository is assumed to be configured on the job and the file is accessed using the readTrusted step.
+If false, the properties files are assumed to be installed locally under the <code>.hamlet/properties</code> directory of the workspace.
+</dd>
+<dt>properties_path</dt>
+<dd>
+The relative path to the properties file, which MUST have a trailing separator and MUST NOT have a leading separator.
+The default is <code>pipelines/properties/</code>.
+</dd>
+<dt>properties_extension</dt>
+<dd>
+The extension to the properties file, which includes any separator. The default is <code>.properties/</code>.
 </dd>
 </dl>
 </p>

--- a/vars/loadPropertiesFiles.groovy
+++ b/vars/loadPropertiesFiles.groovy
@@ -1,0 +1,28 @@
+// Load a repo to get access to the properties files.
+def call(
+    String repo_url = '',
+    String repo_branch = 'master',
+    String credentialsId = 'github'
+) {
+    dir('.hamlet/properties') {
+        script {
+            if ( repo_url ) {
+                // Need to load the repo - don't include it in changelog calculations
+                git(
+                    url: repo_url,
+                    branch: repo_branch,
+                    credentialsId: credentialsId,
+                    changelog: false,
+                    poll: false
+                )
+            } else {
+                // repo is configured as part of the pipeline
+                // Skip the default commit so we can force the value
+                // of GIT_COMMIT in the environment when updating build
+                // references.
+                checkout scm
+            }
+        }
+    }
+}
+

--- a/vars/loadPropertiesFiles.txt
+++ b/vars/loadPropertiesFiles.txt
@@ -1,0 +1,25 @@
+<p>
+Load a repo to get access to the properties files.
+</p>
+<em>Parameters</em>
+<p>
+<dl>
+<dt>repo_url</dt>
+<dd>
+The full URL to the git repository. If blank, the repo is assumed to be configured on the job itself so
+a checkout is performed. If not blank, the repository is checked out.
+</dd>
+<dt>repo_branch</dt>
+<dd>
+The branch to be loaded. By default <code>master</code> is used.
+</dd>
+<dt>credentialsId</dt>
+<dd>
+The id of the jenkins credential to use to access the git provider. By default <code>github</code> is used.
+</dd>
+
+</dl>
+</p>
+<em>Notes</em>
+<p>
+</p>


### PR DESCRIPTION

## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)

## Description
Refactor properties handling to distinguish it from CMDB management.

The repo associated with any job is now treated as the source of pipeline properties files. If the same repo is needed to construct a CMDB, it is separately loaded.

A number of the previously hardcoded locations are now provided as default values to function parameters.

## Motivation and Context
In preparation for converting the library functions to use the hamlet CLI, refactor properties handling to distinguish it from CMDB management.

## How Has This Been Tested?
Customer deployments

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

