### PR TITLE
refactor: exact cli version

### DIFF
--- a/vars/loadProperties.groovy
+++ b/vars/loadProperties.groovy
@@ -7,14 +7,14 @@ def call(
 ) {
     script {
         if (noWorkspace.toBoolean()) {
-            // Assume CMDB configured on the job
+            // Properties must be configured on the job
             def fileContent = readTrusted path: "${properties_path}${properties_file}${properties_extension}"
             def contextProperties = readProperties interpolate: true, text: fileContent
             contextProperties.each{ k, v -> env["${k}"] ="${v}" }
         } else {
-            // CMDB is local in the workspace
+            // Properties local to the workspace
             dir(".hamlet/properties") {
-                // Load in the properties file from the cmdb
+                // Load in the properties file
                 def contextProperties = readProperties interpolate: true, file: "${properties_path}${properties_file}${properties_extension}";
                 contextProperties.each{ k, v -> env["${k}"] ="${v}" }
             }

--- a/vars/setHamletEngine.groovy
+++ b/vars/setHamletEngine.groovy
@@ -5,9 +5,15 @@ def call(
     String cliVersion = ''
 ) {
     script {
+
         env['required_hamlet_engine'] = engine
         env['update_hamlet_engine'] = update
         env['hamlet_cli_version'] = cliVersion
+
+        // Handle the common case of a specific CLI version
+        if (cliVersion ==~ /^[0-9][0-9.]+$/ ) {
+            env['hamlet_cli_version'] = "==" + cliVersion
+        }
     }
 
     // The agent may already have the required version installed


### PR DESCRIPTION
## Intent of Change
- Refactor (non-breaking change which improves the structure or operation of the implementation)
- New feature (non-breaking change which adds functionality)

## Description
 If a simple version number is provided for the CLI version, add the necessary operator to permit it to be installed as an exact version.

## Motivation and Context
Handle the common case of pinning to an exact version of the CLI.

## How Has This Been Tested?
Customer deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

