### PR TITLE
fix: env var case sensitivity

### DIFF
--- a/vars/setHamletEngine.groovy
+++ b/vars/setHamletEngine.groovy
@@ -1,31 +1,29 @@
 // Set the hamlet engine to use for
 def call(
     String engine,
-    Boolean update = false,
     String cliVersion = ''
 ) {
     script {
 
-        env['required_hamlet_engine'] = engine
-        env['update_hamlet_engine'] = update
-        env['hamlet_cli_version'] = cliVersion
+        env['REQUIRED_HAMLET_ENGINE'] = engine
+        env['REQUIRED_HAMLET_CLI'] = cliVersion
 
         // Handle the common case of a specific CLI version
         if (cliVersion ==~ /^[0-9][0-9.]+$/ ) {
-            env['hamlet_cli_version'] = "==" + cliVersion
+            env['REQUIRED_HAMLET_CLI'] = "==" + cliVersion
         }
     }
 
     // The agent may already have the required version installed
     sh '''#!/bin/bash
 
-        echo "Updating the hamlet cli ${hamlet_cli_version:+to (${hamlet_cli_version})}..."
-        pip install --quiet --upgrade "hamlet${hamlet_cli_version}"
+        echo "Updating the hamlet cli ${REQUIRED_HAMLET_CLI:+(${REQUIRED_HAMLET_CLI})} ..."
+        pip install --quiet --upgrade "hamlet${REQUIRED_HAMLET_CLI}"
         echo "hamlet version = \"$(hamlet --version)\""
 
-        echo "Updating the hamlet engine to ${required_hamlet_engine} ..."
-        hamlet engine install-engine --update "${required_hamlet_engine}"
-        hamlet engine set-engine "${required_hamlet_engine}"
+        echo "Updating the hamlet engine (${REQUIRED_HAMLET_ENGINE}) ..."
+        hamlet engine install-engine --update "${REQUIRED_HAMLET_ENGINE}"
+        hamlet engine set-engine "${REQUIRED_HAMLET_ENGINE}"
         echo "hamlet engine = \"$(hamlet engine get-engine)\""
     '''
 }


### PR DESCRIPTION
## Intent of Change
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to change)

## Description
Change the names and case of the local variables to avoid issues with Jenkins' handling of case sensitivity in environment variables.

Also remove the now redundant `update` parameter.



## Motivation and Context
When setting an environment variable, if an upper case version already exists, Jenkins will set it even if a lower case version
of the variable name is used. This doesn't work well if the variable is then used in a bash script.

With the move to v2 of the library from a tagging perspective, incorporate the removal of the redundant attribute.

## How Has This Been Tested?
Customer deployment

## Related Changes
<!--- If anything not covered by the headings below, add here  -->

### Prerequisite PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Dependent PRs:
<!--- Add a checklist of items or leave the default of "None" -->
- None

### Consumer Actions:
<!--- Add a checklist of items or leave the default of "None"
What changes must a consumer of this repository make in order to utilise it?
-->
- None

